### PR TITLE
ページネーションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'faker'
 # ページネーション
 gem 'kaminari'
+gem 'bootstrap5-kaminari-views'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'jbuilder', '~> 2.7'
 
 # サンプル作成のためのFaker
 gem 'faker'
+# ページネーション
+gem 'kaminari'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,18 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -193,6 +205,7 @@ DEPENDENCIES
   dotenv-rails
   faker
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
+    bootstrap5-kaminari-views (0.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.1.9)
@@ -201,6 +204,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bootstrap5-kaminari-views
   byebug
   dotenv-rails
   faker

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   def index
-    @articles = Article.order("#{sort_column} #{sort_direction}").page(params[:page]).per(10)
+    @articles = Article.all.order("#{sort_column} #{sort_direction}").page(params[:page]).per(10)
   end
 
   def show

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   def index
-    @articles = Article.all.order("#{sort_column} #{sort_direction}")
+    @articles = Article.order("#{sort_column} #{sort_direction}").page(params[:page]).per(10)
   end
 
   def show

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -12,9 +12,7 @@ class EmployeesController < ApplicationController
 
   def create
     @employee = Employee.new(employee_params)
-
     # add_params
-
     if @employee.save
       redirect_to employees_url, notice: "社員「#{@employee.last_name} #{@employee.first_name}」を登録しました。"
     else
@@ -27,7 +25,6 @@ class EmployeesController < ApplicationController
 
   def update
     # add_params
-
     if @employee.update(employee_params)
       redirect_to employees_url, notice: "社員「#{@employee.last_name} #{@employee.first_name}」を更新しました。"
     else
@@ -41,7 +38,6 @@ class EmployeesController < ApplicationController
       @employee.update_column(:deleted_at, now)
       @employee.profiles.active.first.update_column(:deleted_at, now) if @employee.profiles.active.present?
     end
-
     redirect_to employees_url, notice: "社員「#{@employee.last_name} #{@employee.first_name}」を削除しました。"
   end
 

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -3,7 +3,7 @@ class EmployeesController < ApplicationController
   before_action :set_form_option, only: %i(new create edit update)
 
   def index
-    @employees = Employee.active.order("#{sort_column} #{sort_direction}")
+    @employees = Employee.active.order("#{sort_column} #{sort_direction}").page(params[:page]).per(20)
   end
 
   def new

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -31,7 +31,7 @@
           </tr>
         <% end %>
       </tr>
-      <%= paginate(@articles) %>
+      <%= paginate @articles, theme: 'bootstrap-5' %>
     </tbody>
   </table>
 

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -31,6 +31,7 @@
           </tr>
         <% end %>
       </tr>
+      <%= paginate(@articles) %>
     </tbody>
   </table>
 

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -37,6 +37,7 @@
           <% end %>
         </tr>
       <% end %>
+      <%= paginate(@employees) %>
     </tbody>
   </table>
 </div>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -37,7 +37,7 @@
           <% end %>
         </tr>
       <% end %>
-      <%= paginate(@employees) %>
+      <%= paginate @employees, theme: 'bootstrap-5' %>
     </tbody>
   </table>
 </div>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -18,12 +18,12 @@
         <tr class="employee">
           <% if employee.profiles.active.present? %>
             <% if employee == current_user %>
-              <td><%= link_to employee.number, edit_employee_profile_path(employee, employee.profiles.active.first) %></td>
+              <td><%= link_to format("%06d", employee.number), edit_employee_profile_path(employee, employee.profiles.active.first) %></td>
             <% else %>
-              <td><%= link_to employee.number, employee_profile_path(employee, employee.profiles.active.first) %></td>
+              <td><%= link_to format("%06d", employee.number), employee_profile_path(employee, employee.profiles.active.first) %></td>
             <% end %>
           <% else %>
-            <td><%= link_to employee.number, employee_profiles_path(employee) %></td>
+            <td><%= link_to format("%06d", employee.number), employee_profiles_path(employee) %></td>
           <% end %>
           <td class="name"><%= "#{employee.last_name} #{employee.first_name}" %></td>
           <td><%= employee.department.name %></td>

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: ""
+          one: "<strong>1-1</strong>/1件中"
+          other: "<strong>1-%{count}</strong>/%{count}件中"
+      more_pages:
+        display_entries: "<strong>%{first}-%{last}</strong>/%{total}件中"


### PR DESCRIPTION
## gem kaminariを追加
+ employees/indexは20行表示
+ articles/indexは10行表示

## kaminariにbootstrap5を適用
+ デザイン調整のため

# 改善点
## employees/indexのnumberのソート順が変
### 原因
+ numberがString型であるため

### 対策
+ @employeesを呼び出すときにnumberをInteger型に変換する
  + 難しいので後回しにする
  + 11/12までに方法が分からなかったら下の方法にする
+ Employeeモデルのnumberの型をIntegerに変更する
  + デメリット
    + 社員番号が「A-0001」のような文字列との組み合わせ時にエラーが起きそう